### PR TITLE
Support creation of configuration versions

### DIFF
--- a/tfc_client/models/__init__.py
+++ b/tfc_client/models/__init__.py
@@ -45,5 +45,6 @@ from .var import VarModel
 from .run import RunModel
 from .data import DataModel
 from .ssh_key import SshKeyModel
+from .configuration_version import ConfigurationVersionModel
 from .notification_configuration import NotificationConfigurationModel
 from .oauth_token import OauthTokenModel

--- a/tfc_client/models/configuration_version.py
+++ b/tfc_client/models/configuration_version.py
@@ -1,0 +1,17 @@
+
+from typing import Dict, List, Optional
+
+from pydantic import HttpUrl
+
+from .data import AttributesModel
+
+
+class ConfigurationVersionModel(AttributesModel):
+    auto_queue_runs: Optional[bool]
+    error: Optional[str]
+    error_message: Optional[str]
+    source: Optional[str]
+    status: Optional[str]
+    status_timestamps: Optional[Dict]
+    upload_url: Optional[HttpUrl]
+    changed_files: Optional[List[str]]

--- a/tfc_client/tfc_objects.py
+++ b/tfc_client/tfc_objects.py
@@ -290,7 +290,8 @@ class TFCRun(TFCObject):
 
 class TFCWorkspace(TFCObject, Paginable, Modifiable, Creatable, Assignable):
     type = "workspaces"
-    can_create = ["vars", "runs", "notification-configurations"]
+    can_create = ["vars", "runs", "notification-configurations",
+                  "configuration-versions"]
 
     def get_list(
         self, object_type: str, filters: Mapping = None, url_prefix=None
@@ -328,7 +329,7 @@ class TFCWorkspace(TFCObject, Paginable, Modifiable, Creatable, Assignable):
         if object_type in ["runs", "vars"]:
             url_prefix = ""
             kwargs["workspace"] = self
-        if object_type in ["notification-configurations"]:
+        if object_type in ["notification-configurations", "configuration-versions"]:
             url_prefix = f"workspaces/{self.id}"
         if object_type in ["runs"]:
             if not kwargs["message"]:

--- a/tfc_client/tfc_objects.py
+++ b/tfc_client/tfc_objects.py
@@ -3,8 +3,7 @@ import hashlib
 import importlib
 import re
 import time
-from io import BytesIO
-from typing import Generator, List, Callable, TYPE_CHECKING, Union
+from typing import BinaryIO, Generator, List, Callable, TYPE_CHECKING, Union
 
 import requests
 
@@ -425,7 +424,7 @@ class TFCStateVersion(TFCObject):
 class TFCConfigurationVersion(TFCObject):
     type = "configuration-versions"
 
-    def upload(self, data: Union[bytes, BytesIO]) -> None:
+    def upload(self, data: Union[bytes, BinaryIO]) -> None:
         resp = requests.put(
             self.upload_url, data,
             headers={'Content-Type': 'application/octet-stream'})

--- a/tfc_client/tfc_objects.py
+++ b/tfc_client/tfc_objects.py
@@ -3,7 +3,10 @@ import hashlib
 import importlib
 import re
 import time
-from typing import Generator, List, Callable, TYPE_CHECKING
+from io import BytesIO
+from typing import Generator, List, Callable, TYPE_CHECKING, Union
+
+import requests
 
 from .models.data import RootModel, DataModel, AssignModel
 from .models.run import RunModel
@@ -421,6 +424,12 @@ class TFCStateVersion(TFCObject):
 
 class TFCConfigurationVersion(TFCObject):
     type = "configuration-versions"
+
+    def upload(self, data: Union[bytes, BytesIO]) -> None:
+        resp = requests.put(
+            self.upload_url, data,
+            headers={'Content-Type': 'application/octet-stream'})
+        resp.raise_for_status()
 
 
 class TFCUser(TFCObject):


### PR DESCRIPTION
This adds just enough plumbing to support configuration version creation and upload:

    cfg = workspace.create('configuration-version')
    with open('config.tar.gz', 'rb') as f:
        cfg.upload(f)

As per documentation: 
  * https://www.terraform.io/docs/cloud/run/api.html
  * https://www.terraform.io/docs/cloud/api/configuration-versions.html